### PR TITLE
Support for templates namespace, prefix and postfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ Default: `function(content) { return content; };`
 
 This option accepts a function that lets you perform additional content processing.
 
+#### prefix
+Type: `String`
+Default: ''
+
+Insert arbitrary text before compiled templates. For example, you might wish to create your namespace before putting templates into it. See usage example below.
+
+#### postfix
+Type: `String`
+Default: ''
+
+Insert arbitrary text after compiled templates.
+
+
 ### Usage Examples
 
 ```js
@@ -79,6 +92,8 @@ ejs: {
     options: {
       open : "<%",
       close: "%>",
+      namespace: 'templates',
+      prefix: 'if (!window.templates) { window.templates = {}; }',
       data: {
         test: true,
         year: '<%= grunt.template.today("yyyy") %>',

--- a/docs/ejs-options.md
+++ b/docs/ejs-options.md
@@ -61,3 +61,16 @@ options: {
 ```
 
 This option accepts a function that lets you perform additional content processing.
+
+#### prefix
+Type: `String`
+Default: ''
+
+Insert arbitrary text before compiled templates. For example, you might wish to create your namespace before putting templates into it. See usage example below.
+
+#### postfix
+Type: `String`
+Default: ''
+
+Insert arbitrary text after compiled templates.
+

--- a/tasks/ejs.js
+++ b/tasks/ejs.js
@@ -25,6 +25,7 @@ module.exports = function(grunt) {
     this.files.forEach(function(fileitem) {
 
       var templates = [];
+      if (options.prefix) { templates.push(options.prefix); }
 
       if (fileitem.src.length < 1) {
         grunt.log.warn('File "' + chalk.red(fileitem.orig.src) + '" not found.');
@@ -56,6 +57,8 @@ module.exports = function(grunt) {
 
         templates.push(compiled);
       });
+
+      if (options.postfix) { templates.push(options.postfix); }
 
       if (templates.length < 1) {
         grunt.log.warn('Destination not written because compiled files were empty.');

--- a/tasks/ejs.js
+++ b/tasks/ejs.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+var path = require('path');
+
 module.exports = function(grunt) {
   var chalk = require('chalk'),
     parseContent = function(content) {
@@ -36,6 +38,8 @@ module.exports = function(grunt) {
 
         var fileContent = processContent(grunt.file.read(filepath)),
           compiled,
+          nsCompiled,
+          tplName,
           compileFn;
 
         options.filename = filepath;
@@ -48,6 +52,8 @@ module.exports = function(grunt) {
 
           compileFn = ejs.compile(fileContent, options);
           compiled = options.client ? compileFn : compileFn(fileitem.orig.data);
+          tplName = path.basename(options.filename, path.extname(options.filename));
+          nsCompiled = options.namespace + '["' + tplName + '"] = ' + compiled + ';\n';
 
         } catch (e) {
           grunt.log.error(e);
@@ -55,7 +61,7 @@ module.exports = function(grunt) {
           return false;
         }
 
-        templates.push(compiled);
+        templates.push(options.namespace ? nsCompiled: compiled);
       });
 
       if (options.postfix) { templates.push(options.postfix); }


### PR DESCRIPTION
Hello lxj,

I suggest to add this functionality. It allows, for example, the following work pattern:

```
    ejs: {
            compile: {
                files: {
                    'js/templates.js': ['ejs/*.ejs']
                },
                options: {
                    client: true,
                    namespace: 'templates',
                    prefix: 'if (!window.templates) { window.templates = {}; };',
                }
            }
        }
```

Then _js/templates.js_ can be simply included into webpage (or JS bundle) and templates can be accessed via window.templates.

This is similar to what is offered by (https://github.com/christophehurpeau/gulp-ejs-precompiler)[gulp-ejs-precompiler] plugin for Gulp.
